### PR TITLE
Update eidas-metadata-servicelist-1.0.xsd

### DIFF
--- a/eidas/eidas-metadata-servicelist-1.0.xsd
+++ b/eidas/eidas-metadata-servicelist-1.0.xsd
@@ -10,7 +10,7 @@
 
   <xs:annotation>
     <xs:documentation>
-      Document identifier: eidas-metadata-servicelist-1.0 
+      Document identifier: eidas-metadata-servicelist-1.0
     </xs:documentation>
   </xs:annotation>
 
@@ -63,7 +63,7 @@
   <xs:complexType name="SchemeInformationType">
     <xs:annotation>
       <xs:documentation>
-        Scheme information about a published metadata service list, where the publisher 
+        Scheme information about a published metadata service list, where the publisher
         and territory are included.
       </xs:documentation>
     </xs:annotation>
@@ -108,7 +108,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element ref="ds:KeyInfo" minOccurs="0">
+      <xs:element ref="ds:KeyInfo" minOccurs="0" maxOccurs="unbounded">
         <xs:annotation>
           <xs:documentation>
             Key material (usually a certificate) that should be used to verify the signature


### PR DESCRIPTION
This update reflects an agreed update on the MDSL schema that allows storage of more than one metadata certificate per metadata location.

This was updated after eIDAS protocol version 1.2

This change is compatible with the new version 1.4 of the eIDSA technical specifications, recently approved.